### PR TITLE
[Leo] Add inline assembly.

### DIFF
--- a/aleo.abnf
+++ b/aleo.abnf
@@ -1,4 +1,4 @@
-; Copyright (C) 2022 Aleo Systems Inc.
+; Copyright (C) 2023 Aleo Systems Inc.
 ; This file is part of the Aleo library.
 
 ; The Leo library is free software: you can redistribute it and/or modify

--- a/leo.abnf
+++ b/leo.abnf
@@ -1,4 +1,4 @@
-; Copyright (C) 2019-2022 Aleo Systems Inc.
+; Copyright (C) 2019-2023 Aleo Systems Inc.
 ; This file is part of the Aleo library.
 
 ; The Leo library is free software: you can redistribute it and/or modify
@@ -98,10 +98,13 @@ not-line-feed-or-carriage-return = horizontal-tab
                                  ; anything but <LF> and <CR>
 
 keyword = %s"address"
+        / %s"as"
+        / %s"asm"
         / %s"assert"
         / %s"assert_eq"
         / %s"assert_neq"
         / %s"bool"
+        / %s"by"
         / %s"console"
         / %s"constant"
         / %s"decrement"
@@ -119,8 +122,9 @@ keyword = %s"address"
         / %s"if"
         / %s"import"
         / %s"in"
-        / %s"inline"
         / %s"increment"
+        / %s"inline"
+        / %s"into"
         / %s"let"
         / %s"mapping"
         / %s"private"
@@ -129,6 +133,7 @@ keyword = %s"address"
         / %s"record"
         / %s"return"
         / %s"scalar"
+        / %s"self"
         / %s"string"
         / %s"struct"
         / %s"then"
@@ -425,6 +430,7 @@ statement = return-statement
           / increment-statement
           / decrement-statement
           / block
+          / assembly
 
 block = "{" *statement "}"
 
@@ -483,6 +489,28 @@ increment-statement =
 
 decrement-statement =
     %s"decrement" "(" identifier "," expression "," expression [ "," ] ")" ";"
+
+assembly = %s"asm" "{" *instruction "}"
+
+instruction-operand = [ "-" ] numeric-literal
+                    / boolean-literal
+                    / address-literal
+                    / string-literal
+                    / identifier *( "." identifier )
+                    / %s"self" "." %s"caller"
+
+unary-instruction = identifier instruction-operand %s"into" identifier ";"
+
+binary-instruction = identifier 2instruction-operand %s"into" identifier ";"
+
+ternary-instruction = identifier 3instruction-operand %s"into" identifier ";"
+
+assert-instruction = %s"assert" 2instruction-operand ";"
+
+instruction = unary-instruction
+            / binary-instruction
+            / ternary-instruction
+            / assert-instruction
 
 function-declaration = *annotation %s"function" identifier
                        "(" [ function-parameters ] ")"


### PR DESCRIPTION
In order to keep lexing context-independent (and thus simpler, doable as a first pass prior to parsing, as opposing to having the parser call the lexer to get the next token), we add a few keywords that are only used in assembly blocks.

(We also swap two existing keywords, `inline` and `increment`, which were out of order for some reason. This swap is unrelated to inline assembly.)

Note that the `caller` in `self.caller` is an identifier, not a keyword. This seems more flexible, as we may add more such accessors, and there is no syntactic ambiguity.

We allow negated literals as operands. This causes no issues in inline instructions, which do not have expressions like `x-1` as in the rest of Leo, which is the reason why Leo does not have negative literals (because otherwise the longest lexeme rule would lex `x-1` as the identifier `x` followed by the negative literal `-1`).

We allow operands that are non-empty sequences separated by `.`, but we do not have a separate syntactic alternative for program IDs, which have the form `<identifier>.<identifier>`, because that would create an ambiguity. This issue is being discussed separately.

Consistently with our treatment of `operator-call`s in Leo, we do not list all instructions, but instead we categorize them based on their "shape":
- 1 input to 1 output
- 2 inputs to 1 output
- 3 inputs to 1 output
- 2 inputs to 0 outputs

We use 'unary', 'binary', and 'ternary' for the first three, while the fourth one is just for `assert`, and so we call it like that.

Note that, based on previous discussions, not all Aleo instructions have counterparts here, by design.